### PR TITLE
removed spaces in macro to enforce that if textValue is empty the res…

### DIFF
--- a/macros_common_general.ftl
+++ b/macros_common_general.ftl
@@ -184,12 +184,10 @@
 </#macro>
 
 <#macro text textValue="" format="">
-
 <#if textValue?has_content && format=="literal">
 <#escape x as x?html>
 <para role="i6LiteralText">${textValue}</para>
 </#escape>
-	
 <#elseif textValue?has_content>
 <#compress>
 <#escape x as x?html>


### PR DESCRIPTION
…ult of the macro will also be empty (and not a blank char)