### PR TITLE
function sanitizeUUID added

### DIFF
--- a/macros_common_general.ftl
+++ b/macros_common_general.ftl
@@ -1006,3 +1006,19 @@ ${textValue}
 	<#return otherProds/>
 </#function>
 
+<#-- sanitizeUUID sanitises the UUID in order to keep just the second part after the '/', 
+     which corresponds to the dossier (first part is dataset) 
+-->
+<#function sanitizeUUID uuidPath>
+
+    <#local uuid><@com.text uuidPath/></#local>
+    
+    <#if uuid?matches(".{2,50}/.{2,50}", "r")>
+        <#local uuid=uuid?replace(".*/", '', 'r')/>
+    </#if>
+    
+    <#return uuid/>
+</#function>
+
+
+


### PR DESCRIPTION
A new function sanitizeUUID has been added to macros_common_general which sanitises the UUID in order to keep just the second part after the '/',  which corresponds to the dossier (first part is dataset) 
